### PR TITLE
Updating python driver open to io.open

### DIFF
--- a/src/drivers/python/setup.py
+++ b/src/drivers/python/setup.py
@@ -1,3 +1,4 @@
+import io
 import os.path
 from setuptools import setup
 
@@ -15,7 +16,7 @@ except ImportError:
     bdist_wheel = None
 
 def readme():
-    with open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'rU') as f:
+    with io.open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'r') as f:
         return f.read()
 
 setup(


### PR DESCRIPTION
Fixes #28 

Updates python driver `setup.py` to use `io.open` instead of `open`