### PR TITLE
Update src/drivers/schism/fabm_driver.h with MASK definitions

### DIFF
--- a/src/drivers/schism/fabm_driver.h
+++ b/src/drivers/schism/fabm_driver.h
@@ -13,7 +13,12 @@
 
 #define _FABM_MASK_TYPE_ integer
 #define _FABM_MASKED_VALUE_ 1
-#define _FABM_HORIZONTAL_MASK_
 
+! For performance reasons it would be advisable to define _FABM_HORIZONTAL_MASK_
+! which is sufficient to mask dry elements.  It currently does break the 
+! code however, which still employs a 2D mask to mask elements below the bottom index
+! within a water column.  We need a discussion on whether it is more performant to 
+! do the calculations below bottom index nonetheless ... 
+   
 #include "fabm.h"
 

--- a/src/drivers/schism/fabm_driver.h
+++ b/src/drivers/schism/fabm_driver.h
@@ -1,7 +1,8 @@
-! Copyright 2017 Helmholtz-Zentrum Geesthacht
-! Licensed under the Apache License, Version 2.0
-!  (http://www.apache.org/licenses/LICENSE-2.0)
-! Author(s): Richard Hofmeister
+! SPDX-FileCopyrightText: 2021-2024 Helmholtz-Zentrum hereon GmbH
+! SPDX-FileCopyrightText: 2017-2021 Helmholtz-Zentrum Geesthacht GmbH
+! SPDX-License-Identifier: CC0-1.0
+! SPDX-FileContributor: Carsten Lemmen <carsten.lemmen@hereon.de>
+! SPDX-FileContributor: Richard Hofmeister
 
 #define _FABM_DIMENSION_COUNT_ 2
 #define _FABM_DEPTH_DIMENSION_INDEX_ 1
@@ -10,4 +11,8 @@
 #define _FABM_VERTICAL_BOTTOM_TO_SURFACE_
 #define _FABM_BOTTOM_INDEX_ -1
 
+#define _FABM_MASK_TYPE_ integer
+#define _FABM_MASKED_VALUE_ 1
+
 #include "fabm.h"
+

--- a/src/drivers/schism/fabm_driver.h
+++ b/src/drivers/schism/fabm_driver.h
@@ -13,6 +13,7 @@
 
 #define _FABM_MASK_TYPE_ integer
 #define _FABM_MASKED_VALUE_ 1
+#define _FABM_HORIZONTAL_MASK_
 
 #include "fabm.h"
 


### PR DESCRIPTION
Recent versions of SCHISM need the MASK_TYPE and MASK_VALUE to be defined in the driver.  This Commit adds the relevant definitions.  We also update copyright and license (placed in public domain).