### PR TITLE
Update fabm0d's gotm interface

### DIFF
--- a/src/drivers/0d/fabm0d.F90
+++ b/src/drivers/0d/fabm0d.F90
@@ -14,7 +14,7 @@
 ! !USES:
    use time
    use input
-   use eqstate,only:rho_feistel
+   use density,only:get_rho
 
    use fabm
    use fabm_driver
@@ -616,7 +616,7 @@
       if (model_type==1) column_depth = mixed_layer_depth%value
 
       ! Compute density from temperature and salinity, if required by biogeochemistry.
-      if (compute_density) dens = rho_feistel(salt%value,temp%value,0.5_rk*column_depth,.true.)
+      if (compute_density) dens = get_rho(salt%value,temp%value,0.5_rk*column_depth)
    end subroutine update_environment
 
    subroutine update_light()


### PR DESCRIPTION
The fabm0d.F90 in this repo failed to compile when I followed this instruction (https://github.com/fabm-model/fabm/wiki/0D-driver).
The error comes from the outdated utils in GOTM, which uses a `density` module

```bash
   17 |    use eqstate,only:rho_feistel
      |        1
Fatal Error: Cannot open module file 'eqstate.mod' for reading at (1): No such file or directory
compilation terminated.
gmake[2]: *** [CMakeFiles/fabm0d.dir/build.make:91: CMakeFiles/fabm0d.dir/fabm0d.F90.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:991: CMakeFiles/fabm0d.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

updating it to `use density,only:get_rho` resolves the bug.